### PR TITLE
Adds "workspace" property to "deployment" schema

### DIFF
--- a/docs/pipelines/yaml-schema.md
+++ b/docs/pipelines/yaml-schema.md
@@ -480,6 +480,8 @@ jobs:
   pool:                # see the following "Pool" schema
     name: string
     demands: string | [ string ]
+  workspace:
+    clean: outputs | resources | all # what to clean up before the job runs
   dependsOn: string
   condition: string
   continueOnError: boolean                # 'true' if future jobs should run even if this job fails; defaults to 'false'


### PR DESCRIPTION
Adds missing "workspace" property to the "deployment" job schema, matching the one found on the "job" schema

I thought it wasn't supported yet from my personal experience it seems to work as expected in my own pipelines (clean up the workspace folder)